### PR TITLE
📝 Add SEAL 911 Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,17 @@
+# SEAL 911 Code of Conduct
+
+1. We Are Accountable
+2. We Act Ethically
+3. We Protect Our Information and Assets
+
+## 1. We Are Accountable
+
+We are aware that many people entrust us with sensitive information. If we abuse this trust in any way, we lose our purpose of being a trustworthy point of contact for incidents. So let us act accordingly and take this responsibility seriously.
+
+## 2. We Act Ethically
+
+We do not exploit our information advantage in any way to gain a personal, commercial, or other malicious advantage. Our aim is always to achieve the best possible result for the victim. Misuse of information is not tolerated and will result in the removal from SEAL 911. **Simply put: Don't be a dick!**
+
+## 3. We Protect Our Information and Assets
+
+In one sentence: We handle information carefully, as you would expect from security professionals. Do NOT share information outside of the [SEAL 911 Telegram bot](https://t.me/seal_911_bot) unless it is needed for the incident. We should always assume that information is confidential unless we have knowledge that the victim or another party has made the information public or has the right to release it.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ SEAL 911 is a project designed to give users, developers, and even other securit
 Given the high trust required for this project to function, membership is available on an invite-only basis. Typically, at least one existing member will vouch for the new member. Commercial organizations are limited to a maximum of two members.
 
 ## Members
+
 The current list of members is available below, for transparency purposes.
 
 - 0xc0ffeebabe
@@ -45,3 +46,7 @@ The current list of members is available below, for transparency purposes.
 - Ohm (Wallet Guard)
 - FrankResearcher (Wintermute)
 - Storm0x (Yearn)
+
+## SEAL 911 Code of Conduct
+
+See [here](./CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Adds the official SEAL 911 Code of Conduct. My original draft can be found [here](https://gist.github.com/pcaversaccio/87951f1dc5d69fe7d820fa0f0634b547).