### PR TITLE
📝 Add Further SEAL 911 Members

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The current list of members is available below, for transparency purposes.
 - Ohm (Wallet Guard)
 - FrankResearcher (Wintermute)
 - Storm0x (Yearn)
+- Pablo Sabbatella (Blockfence)
 
 ## SEAL 911 Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The current list of members is available below, for transparency purposes.
 - FrankResearcher (Wintermute)
 - Storm0x (Yearn)
 - Pablo Sabbatella (Blockfence)
+- Sipan V'artagnan (Hexens)
 
 ## SEAL 911 Code of Conduct
 


### PR DESCRIPTION
This PR adds the following members to the SEAL 911 list:

- Pablo Sabbatella (Blockfence)
- Sipan V'artagnan (Hexens)