### PR TITLE
📝 Update SEAL 911 Multisig Address

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ You can find [here](./ACTIVITY.md) a continually evolving, albeit incomplete, pu
 
 ## Donations
 
-The SEAL 911 multisig (3-of-5) is deployed on Ethereum at address [`0xba5Ed9942ea64e8D789187E0aF6a0390d78BA5ed`](https://etherscan.io/address/0xba5Ed9942ea64e8D789187E0aF6a0390d78BA5ed).
+You can support the SEAL 911 volunteers by donating to their 3-of-5 multisig: [`0xba5Ed9942ea64e8D789187E0aF6a0390d78BA5ed`](https://etherscan.io/address/0xba5Ed9942ea64e8D789187E0aF6a0390d78BA5ed).

--- a/README.md
+++ b/README.md
@@ -71,15 +71,4 @@ You can find [here](./ACTIVITY.md) a continually evolving, albeit incomplete, pu
 
 ## Donations
 
-The SEAL 911 multisig (5-of-7) is deployed at address `0x911abFc05B70B99E921C1753e34475a390B4ff58` across the following networks:
-
-- [Ethereum](https://etherscan.io/address/0x911abFc05B70B99E921C1753e34475a390B4ff58)
-- [Optimism](https://optimistic.etherscan.io/address/0x911abFc05B70B99E921C1753e34475a390B4ff58)
-- [Binance](https://bscscan.com/address/0x911abFc05B70B99E921C1753e34475a390B4ff58)
-- [Polygon](https://polygonscan.com/address/0x911abFc05B70B99E921C1753e34475a390B4ff58)
-- [Base](https://basescan.org/address/0x911abFc05B70B99E921C1753e34475a390B4ff58)
-- [Arbitrum](https://arbiscan.io/address/0x911abFc05B70B99E921C1753e34475a390B4ff58)
-- [Linea](https://lineascan.build/address/0x911abFc05B70B99E921C1753e34475a390B4ff58)
-- [Scroll](https://scrollscan.com/address/0x911abFc05B70B99E921C1753e34475a390B4ff58)
-
-On ZKsync Era, the SEAL 911 multisig (5-of-7) is deployed at address [`0x265d1C1B10E644014D461b65a2e5414D3686cF22`](https://era.zksync.network/address/0x265d1C1B10E644014D461b65a2e5414D3686cF22).
+The SEAL 911 multisig (3-of-5) is deployed on Ethereum at address [`0xba5Ed9942ea64e8D789187E0aF6a0390d78BA5ed`](https://etherscan.io/address/0xba5Ed9942ea64e8D789187E0aF6a0390d78BA5ed).


### PR DESCRIPTION
### 🕓 Changelog

The current SEAL 911 multisigs at `0x911abFc05B70B99E921C1753e34475a390B4ff58` and `0x265d1C1B10E644014D461b65a2e5414D3686cF22` (ZKsync Era) will be transferred to SEAL, the legal entity. In contrast, the new SEAL 911 multisig at `0xba5Ed9942ea64e8D789187E0aF6a0390d78BA5ed` is entirely _independent_ of the SEAL legal entity and fully controlled by the SEAL 911 members.