### PR TITLE
💸 Add Giveth Link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+custom:
+  [
+    https://etherscan.io/address/0xba5Ed9942ea64e8D789187E0aF6a0390d78BA5ed,
+    https://giveth.io/project/seal-911,
+  ]

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,14 +14,14 @@ jobs:
         os:
           - ubuntu-latest
         node_version:
-          - 20
+          - 24
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Use Node.js ${{ matrix.node_version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node_version }}
 
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run codespell
         uses: codespell-project/actions-codespell@v2


### PR DESCRIPTION
### 🕓 Changelog

This PR adds the official SEAL 911 Giveth [link](https://giveth.io/project/seal-911) and the SEAL 911 multisig address [`0xba5Ed9942ea64e8D789187E0aF6a0390d78BA5ed`](https://etherscan.io/address/0xba5Ed9942ea64e8D789187E0aF6a0390d78BA5ed) to the newly created [`FUNDING.yml`](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository) file. It also upgrades the GitHub CI Actions in `checks.yml` to their latest available versions and updates the Node.js runtime to `v24`.